### PR TITLE
Add modular TQQQ/SQQQ backtesting framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.cache/
+registry.sqlite
+synthetic.parquet

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Whitelight
+
+Backtester y Monte Carlo para estrategias sistemáticas TQQQ/SQQQ. Este paquete descarga datos de `yfinance`, genera series apalancadas sintéticas y ejecuta un backtest EOD totalmente programático. Incluye ejemplos de uso en la CLI y disclaimers de riesgo.
+
+**Descargo de responsabilidad:** "CAGR backtest ~80% y MDD ~49% observados históricamente no garantizan resultados futuros".

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "whitelight"
+version = "0.1.0"
+description = "EOD backtester and Monte Carlo search for TQQQ/SQQQ strategies"
+authors = [{name="Quant"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "pandas",
+    "numpy",
+    "scipy",
+    "statsmodels",
+    "matplotlib",
+    "pydantic",
+    "tqdm",
+    "joblib",
+    "numba",
+    "yfinance",
+    "pandas_market_calendars",
+    "tenacity",
+    "diskcache",
+    "typer",
+]
+
+[project.scripts]
+whitelight = "whitelight.cli:app"

--- a/src/whitelight/__init__.py
+++ b/src/whitelight/__init__.py
@@ -1,0 +1,18 @@
+"""Whitelight package.
+
+Herramientas para backtesting EOD y búsqueda Monte Carlo de estrategias
+sobre TQQQ/SQQQ.
+"""
+
+__all__ = [
+    "data",
+    "synthetic",
+    "indicators",
+    "position_sizing",
+    "strategy",
+    "broker_sim",
+    "portfolio",
+    "montecarlo",
+    "registry",
+    "reports",
+]

--- a/src/whitelight/broker_sim.py
+++ b/src/whitelight/broker_sim.py
@@ -1,0 +1,31 @@
+"""Broker simulation and adapter interfaces."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class BrokerAdapter(Protocol):
+    """Minimal interface for future real-broker connections."""
+
+    def submit_order(self, symbol: str, qty: int, side: str) -> None:
+        ...
+
+    def get_position(self, symbol: str) -> float:
+        ...
+
+
+@dataclass
+class Fill:
+    symbol: str
+    qty: int
+    price: float
+    side: str  # 'buy' or 'sell'
+
+
+def simulate_fill(price: float, slippage_bps: float, commission_bps: float, side: str) -> float:
+    """Return execution price including slippage/commission."""
+    slip = price * slippage_bps / 10000
+    comm = price * commission_bps / 10000
+    adj = price + slip if side == "buy" else price - slip
+    return adj + comm

--- a/src/whitelight/cli.py
+++ b/src/whitelight/cli.py
@@ -1,0 +1,95 @@
+"""Command line interface using Typer."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import typer
+
+from . import data, synthetic, strategy, portfolio, registry, reports
+
+app = typer.Typer(help="Whitelight backtesting toolkit")
+
+
+@app.command()
+def download(start: str = "1999-01-01", end: Optional[str] = None) -> None:
+    """Download core datasets and cache them locally."""
+    tickers = ["^NDX", "^GSPC", "TQQQ", "SQQQ"]
+    for t in tickers:
+        df = data.download_price_data(
+            t, pd.to_datetime(start).date(), pd.to_datetime(end).date() if end else None
+        )
+        typer.echo(f"Downloaded {t}: {len(df)} rows")
+
+
+@app.command("make-synthetic")
+def make_synthetic() -> None:
+    ndx = data.download_price_data("^NDX")
+    rets = ndx["close"].pct_change().dropna()
+    t = synthetic.make_leveraged_series(rets, 3.0)
+    s = synthetic.make_leveraged_series(rets, -3.0)
+    out = pd.DataFrame({"tqqq": t, "sqqq": s})
+    out.to_parquet("synthetic.parquet")
+    typer.echo("Saved synthetic series to synthetic.parquet")
+
+
+@app.command()
+def backtest(config: Optional[Path] = None) -> None:
+    """Run backtest using cached data."""
+    ndx = data.download_price_data("^NDX")
+    tqqq = data.download_price_data("TQQQ")
+    sqqq = data.download_price_data("SQQQ")
+    df = pd.concat(
+        [
+            ndx["close"].rename("ndx"),
+            tqqq["close"].rename("tqqq"),
+            sqqq["close"].rename("sqqq"),
+        ],
+        axis=1,
+        join="inner",
+    )
+    equity = strategy.backtest(df)
+    m = portfolio.compute_metrics(equity)
+    reports.plot_equity(equity, "equity.png")
+    reports.plot_drawdown(equity, "drawdown.png")
+    typer.echo(portfolio.metrics_to_json(m))
+
+
+@app.command()
+def montecarlo(n: int = 100) -> None:
+    ndx = data.download_price_data("^NDX")
+    tqqq = data.download_price_data("TQQQ")
+    sqqq = data.download_price_data("SQQQ")
+    df = pd.concat(
+        [
+            ndx["close"].rename("ndx"),
+            tqqq["close"].rename("tqqq"),
+            sqqq["close"].rename("sqqq"),
+        ],
+        axis=1,
+        join="inner",
+    )
+    reg = registry.Registry()
+    from . import montecarlo as mc
+
+    mc.run_montecarlo(df, n, reg)
+    typer.echo("Monte Carlo completed")
+
+
+@app.command()
+def report(model_id: str) -> None:
+    reg = registry.Registry()
+    df = reg.top("sharpe")
+    row = df[df["model_id"] == model_id]
+    if row.empty:
+        typer.echo("model not found")
+    else:
+        typer.echo(row.to_string(index=False))
+
+
+@app.command()
+def top(metric: str = "sharpe", k: int = 20) -> None:
+    reg = registry.Registry()
+    df = reg.top(metric, k)
+    typer.echo(df.to_string(index=False))

--- a/src/whitelight/data.py
+++ b/src/whitelight/data.py
@@ -1,0 +1,75 @@
+"""Data utilities for Whitelight.
+
+Handles download of market data from `yfinance` with retry logic and
+alignment to the US trading calendar. Results are cached locally using
+`diskcache` to avoid repeated downloads.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Iterable, Tuple
+
+import pandas as pd
+import pandas_market_calendars as mcal
+import yfinance as yf
+from diskcache import Cache
+from tenacity import retry, stop_after_attempt, wait_exponential
+from dateutil.relativedelta import relativedelta
+
+CACHE = Cache(".cache")
+
+
+@retry(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=8))
+def _fetch(ticker: str, start: date, end: date) -> pd.DataFrame:
+    return yf.download(
+        ticker,
+        start=start.isoformat(),
+        end=end.isoformat(),
+        interval="1d",
+        auto_adjust=True,
+        progress=False,
+    )
+
+
+def download_price_data(
+    ticker: str,
+    start: date | None = None,
+    end: date | None = None,
+) -> pd.DataFrame:
+    """Download daily data for ``ticker`` between ``start`` and ``end``.
+
+    Data are aligned to the NYSE trading calendar and cached locally. If
+    less than ~20 years of data are available a warning is emitted but the
+    function still returns the maximum history available.
+    """
+    today = date.today()
+    if end is None:
+        end = today
+    if start is None:
+        twenty_five = today - relativedelta(years=25)
+        start = max(date(1999, 1, 1), twenty_five)
+    key = f"{ticker}-{start}-{end}"
+    if key in CACHE:
+        df = CACHE[key]
+    else:
+        raw = _fetch(ticker, start, end)
+        df = raw[["Close"]].rename(columns={"Close": "close"})
+        cal = mcal.get_calendar("XNYS")
+        sched = cal.schedule(start_date=start, end_date=end)
+        all_days = mcal.date_range(sched, frequency="1D")
+        df = df.reindex(all_days, method="ffill")
+        CACHE[key] = df
+    if len(df) < 252 * 20:
+        import warnings
+
+        warnings.warn(
+            f"Historical data for {ticker} less than 20 years ({len(df)} days)",
+            RuntimeWarning,
+        )
+    return df
+
+
+def split_is_oos(data: pd.DataFrame, ratio: float = 0.7) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Split a DataFrame into in-sample and out-of-sample segments."""
+    idx = int(len(data) * ratio)
+    return data.iloc[:idx].copy(), data.iloc[idx:].copy()

--- a/src/whitelight/indicators.py
+++ b/src/whitelight/indicators.py
@@ -1,0 +1,31 @@
+"""Indicator functions used by the strategy."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def ma(series: pd.Series, length: int) -> pd.Series:
+    """Simple moving average."""
+    return series.rolling(length).mean()
+
+
+def bollinger(
+    series: pd.Series, length: int = 20, k: float = 2.0
+) -> tuple[pd.Series, pd.Series, pd.Series, pd.Series]:
+    """Compute Bollinger Bands and z-score."""
+    m = ma(series, length)
+    s = series.rolling(length).std()
+    upper = m + k * s
+    lower = m - k * s
+    z = (series - m) / s
+    return m, upper, lower, z
+
+
+def atr(series: pd.Series, length: int = 14) -> pd.Series:
+    """Average true range using simple method.
+
+    Expects a close price series; returns rolling standard deviation
+    scaled by square-root of time as a crude proxy.
+    """
+    return series.pct_change().rolling(length).std() * np.sqrt(length)

--- a/src/whitelight/montecarlo.py
+++ b/src/whitelight/montecarlo.py
@@ -1,0 +1,45 @@
+"""Monte Carlo hyper-parameter search."""
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from typing import Dict
+
+from joblib import Parallel, delayed
+
+from .portfolio import compute_metrics
+from .registry import Registry
+from .strategy import backtest, DEFAULT_PARAMS
+
+
+@dataclass
+class Result:
+    model_id: str
+    params: Dict[str, float]
+    metrics: Dict[str, float]
+
+
+def _sample(seed: int) -> Dict[str, float]:
+    r = random.Random(seed)
+    return {
+        "ma_fast": r.randint(10, 40),
+        "ma_slow": r.randint(150, 300),
+        "bb_len": r.randint(10, 40),
+        "bb_k": r.uniform(1.5, 3.0),
+    }
+
+
+def _evaluate(df, seed: int) -> Result:
+    params = {**DEFAULT_PARAMS, **_sample(seed)}
+    eq = backtest(df, params)
+    m = compute_metrics(eq)
+    return Result(str(seed), params, m.__dict__)
+
+
+def run_montecarlo(df, n: int, registry: Registry) -> None:
+    def worker(seed: int):
+        res = _evaluate(df, seed)
+        registry.insert(res.model_id, res.params, res.metrics)
+
+    Parallel(n_jobs=-1)(delayed(worker)(s) for s in range(n))

--- a/src/whitelight/portfolio.py
+++ b/src/whitelight/portfolio.py
@@ -1,0 +1,66 @@
+"""Portfolio statistics."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Dict
+
+import numpy as np
+import pandas as pd
+import statsmodels.api as sm
+
+
+@dataclass
+class Metrics:
+    cagr: float
+    vol: float
+    sharpe: float
+    sortino: float
+    mdd: float
+    calmar: float
+    skew: float
+    kurtosis: float
+    trades: int
+    avg_trade: float
+    hit_rate: float
+    alpha: float
+    beta: float
+
+
+def compute_drawdown(equity: pd.Series) -> pd.Series:
+    cummax = equity.cummax()
+    return equity / cummax - 1
+
+
+def compute_metrics(
+    equity: pd.Series,
+    bench: pd.Series | None = None,
+) -> Metrics:
+    returns = equity.pct_change().dropna()
+    ann_factor = 252
+    cagr = equity.iloc[-1] ** (ann_factor / len(equity)) - 1
+    vol = returns.std() * np.sqrt(ann_factor)
+    sharpe = returns.mean() / returns.std() * np.sqrt(ann_factor)
+    downside = returns[returns < 0].std() * np.sqrt(ann_factor)
+    sortino = returns.mean() / downside if downside != 0 else np.nan
+    dd = compute_drawdown(equity)
+    mdd = dd.min()
+    calmar = cagr / abs(mdd) if mdd != 0 else np.nan
+    skew = returns.skew()
+    kurt = returns.kurtosis()
+    trades = (returns != 0).sum()
+    avg_trade = returns.mean()
+    hit_rate = (returns > 0).mean()
+    alpha = beta = np.nan
+    if bench is not None:
+        aligned = pd.concat([returns, bench.pct_change().reindex(returns.index).dropna()], axis=1)
+        aligned.columns = ["r", "b"]
+        X = sm.add_constant(aligned["b"])
+        model = sm.OLS(aligned["r"], X).fit()
+        alpha = model.params["const"] * ann_factor
+        beta = model.params["b"]
+    return Metrics(cagr, vol, sharpe, sortino, mdd, calmar, skew, kurt, trades, avg_trade, hit_rate, alpha, beta)
+
+
+def metrics_to_json(metrics: Metrics) -> str:
+    return json.dumps(metrics.__dict__, indent=2)

--- a/src/whitelight/position_sizing.py
+++ b/src/whitelight/position_sizing.py
@@ -1,0 +1,53 @@
+"""Position sizing helpers."""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def size_by_ma_distance(
+    d20: pd.Series,
+    d250: pd.Series,
+    w1: float = 0.6,
+    w2: float = 0.4,
+    clip_long: float = 1.0,
+    clip_short: float = 1.0,
+    mode: str = "linear",
+) -> pd.Series:
+    """Combine MA distances into a raw exposure signal."""
+    raw = w1 * d20 + w2 * d250
+    if mode == "tanh":
+        raw = np.tanh(raw)
+    return raw.clip(-clip_short, clip_long)
+
+
+def momentum_boost(
+    exposure: pd.Series,
+    z: pd.Series,
+    thresh: float = 1.0,
+    boost_factor: float = 1.5,
+) -> pd.Series:
+    """Amplify exposure when |z| exceeds threshold."""
+    boosted = exposure.copy()
+    mask = z.abs() > thresh
+    boosted[mask] = boosted[mask] * boost_factor
+    return boosted.clip(-1, 1)
+
+
+def compute_target_exposure(
+    price: pd.Series,
+    ma20: pd.Series,
+    ma250: pd.Series,
+    z: pd.Series,
+    w1: float = 0.6,
+    w2: float = 0.4,
+    clip_long: float = 1.0,
+    clip_short: float = 1.0,
+    mode: str = "linear",
+    momentum_thresh: float = 1.0,
+    boost_factor: float = 1.5,
+) -> pd.Series:
+    d20 = price / ma20 - 1.0
+    d250 = price / ma250 - 1.0
+    base = size_by_ma_distance(d20, d250, w1, w2, clip_long, clip_short, mode)
+    return momentum_boost(base, z, momentum_thresh, boost_factor)

--- a/src/whitelight/registry.py
+++ b/src/whitelight/registry.py
@@ -1,0 +1,29 @@
+"""SQLite registry for Monte Carlo runs."""
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from typing import Dict, Iterable
+
+import pandas as pd
+
+
+class Registry:
+    def __init__(self, path: str = "registry.sqlite") -> None:
+        self.conn = sqlite3.connect(path)
+        self.conn.execute(
+            "CREATE TABLE IF NOT EXISTS runs (model_id TEXT PRIMARY KEY, params TEXT, metrics TEXT)"
+        )
+
+    def insert(self, model_id: str, params: Dict, metrics: Dict) -> None:
+        self.conn.execute(
+            "INSERT OR REPLACE INTO runs VALUES (?,?,?)",
+            (model_id, json.dumps(params, default=float), json.dumps(metrics, default=float)),
+        )
+        self.conn.commit()
+
+    def top(self, metric: str, k: int = 20) -> pd.DataFrame:
+        df = pd.read_sql_query("SELECT * FROM runs", self.conn)
+        df[metric] = df["metrics"].apply(lambda x: json.loads(x).get(metric, 0))
+        return df.sort_values(metric, ascending=False).head(k)

--- a/src/whitelight/reports.py
+++ b/src/whitelight/reports.py
@@ -1,0 +1,24 @@
+"""Reporting helpers using matplotlib."""
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from .portfolio import compute_drawdown
+
+
+def plot_equity(equity: pd.Series, path: str) -> None:
+    fig, ax = plt.subplots()
+    equity.plot(ax=ax)
+    ax.set_title("Equity Curve")
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_drawdown(equity: pd.Series, path: str) -> None:
+    dd = compute_drawdown(equity)
+    fig, ax = plt.subplots()
+    dd.plot(ax=ax)
+    ax.set_title("Drawdown")
+    fig.savefig(path)
+    plt.close(fig)

--- a/src/whitelight/strategy.py
+++ b/src/whitelight/strategy.py
@@ -1,0 +1,68 @@
+"""Core strategy logic.
+
+The strategy derives an exposure between -1 and +1 based on NASDAQ-100
+price relative to moving averages and Bollinger bands.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+from .indicators import bollinger, ma
+from .position_sizing import compute_target_exposure
+
+
+DEFAULT_PARAMS = {
+    "ma_fast": 20,
+    "ma_slow": 250,
+    "bb_len": 20,
+    "bb_k": 2.0,
+    "w1": 0.6,
+    "w2": 0.4,
+    "clip_long": 1.0,
+    "clip_short": 1.0,
+    "momentum_thresh": 1.0,
+    "boost_factor": 1.5,
+    "slippage_bps": 2,
+    "commission_bps": 1,
+}
+
+
+def generate_signals(prices_ndx: pd.Series, params: dict | None = None) -> pd.Series:
+    p = {**DEFAULT_PARAMS, **(params or {})}
+    ma20 = ma(prices_ndx, p["ma_fast"])
+    ma250 = ma(prices_ndx, p["ma_slow"])
+    _, _, _, z = bollinger(prices_ndx, p["bb_len"], p["bb_k"])
+    exposure = compute_target_exposure(
+        prices_ndx,
+        ma20,
+        ma250,
+        z,
+        p["w1"],
+        p["w2"],
+        p["clip_long"],
+        p["clip_short"],
+        "linear",
+        p["momentum_thresh"],
+        p["boost_factor"],
+    )
+    return exposure.dropna()
+
+
+def backtest(df: pd.DataFrame, params: dict | None = None) -> pd.Series:
+    """Run a simple backtest given price data.
+
+    ``df`` must contain columns ``ndx``, ``tqqq`` and ``sqqq`` representing
+    price series of the index and ETFs respectively.
+    """
+    exposure = generate_signals(df["ndx"], params)
+    tqqq_ret = df["tqqq"].pct_change().reindex(exposure.index).fillna(0)
+    sqqq_ret = df["sqqq"].pct_change().reindex(exposure.index).fillna(0)
+    target_ret = exposure.clip(lower=0) * tqqq_ret + exposure.clip(upper=0) * sqqq_ret
+    # costs on turnover
+    turns = exposure.diff().abs().fillna(0)
+    p = {**DEFAULT_PARAMS, **(params or {})}
+    slippage = turns * (p["slippage_bps"] / 10000)
+    commission = turns * (p["commission_bps"] / 10000)
+    net_ret = target_ret - slippage - commission
+    equity = (1 + net_ret).cumprod()
+    return equity

--- a/src/whitelight/synthetic.py
+++ b/src/whitelight/synthetic.py
@@ -1,0 +1,43 @@
+"""Synthetic leveraged series for TQQQ/SQQQ.
+
+The real ETFs only have history from 2010. For earlier periods we
+construct synthetic paths based on NASDAQ-100 index returns with daily
+rebalancing and explicit fee/borrow costs.
+"""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def make_leveraged_series(
+    index_returns: pd.Series,
+    leverage: float = 3.0,
+    fee_annual: float = 0.0095,
+    borrow_cost_annual: float = 0.0,
+    daily_rebalance: bool = True,
+) -> pd.Series:
+    """Create a leveraged return series from unlevered ``index_returns``.
+
+    Parameters
+    ----------
+    index_returns : pd.Series
+        Daily return series of the underlying index.
+    leverage : float, default 3.0
+        Leverage factor, negative for inverse exposure.
+    fee_annual : float, default 0.0095
+        Annual management fee applied daily.
+    borrow_cost_annual : float, default 0.0
+        Additional annual borrowing cost for short/inverse products.
+    daily_rebalance : bool, default True
+        Keep leverage constant via daily rebalancing.
+    """
+    days = index_returns.shape[0]
+    fee_daily = (1 + fee_annual) ** (1 / 252) - 1
+    borrow_daily = (1 + borrow_cost_annual) ** (1 / 252) - 1
+    if daily_rebalance:
+        levered_returns = leverage * index_returns
+    else:
+        levered_returns = (1 + index_returns).cumprod().pct_change() * leverage
+    levered_returns = levered_returns - fee_daily - borrow_daily
+    prices = (1 + levered_returns).cumprod()
+    return prices.rename("synthetic")

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,16 @@
+import pandas as pd
+from whitelight.indicators import ma, bollinger
+
+
+def test_ma():
+    s = pd.Series([1, 2, 3, 4, 5])
+    result = ma(s, 2)
+    expected = pd.Series([float("nan"), 1.5, 2.5, 3.5, 4.5])
+    pd.testing.assert_series_equal(result, expected)
+
+
+def test_bollinger():
+    s = pd.Series([1, 2, 3, 4, 5])
+    m, up, low, z = bollinger(s, 2, 2)
+    assert m.iloc[-1] == 4.5
+    assert round(z.iloc[-1], 6) == round((5 - 4.5) / s.iloc[-2:].std(), 6)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,11 @@
+import pandas as pd
+from whitelight.portfolio import compute_metrics
+
+
+def test_metrics_alpha_beta():
+    bench = pd.Series([100, 101, 103, 102])
+    asset = pd.Series([100, 102, 106, 104])
+    m = compute_metrics(asset, bench)
+    assert abs(m.beta - 2) < 0.1
+    assert abs(m.alpha) < 0.1
+    assert m.sharpe > 0

--- a/tests/test_smoke_backtest.py
+++ b/tests/test_smoke_backtest.py
@@ -1,0 +1,20 @@
+import numpy as np
+import pandas as pd
+
+from whitelight import synthetic, strategy, portfolio, registry
+
+
+def test_smoke_backtest(tmp_path):
+    np.random.seed(0)
+    rets = pd.Series(np.random.normal(0, 0.01, 300))
+    ndx = 100 * (1 + rets).cumprod()
+    tqqq = synthetic.make_leveraged_series(rets, 3.0)
+    sqqq = synthetic.make_leveraged_series(rets, -3.0)
+    df = pd.DataFrame({"ndx": ndx, "tqqq": tqqq, "sqqq": sqqq})
+    eq = strategy.backtest(df)
+    assert eq.iloc[-1] != 0
+    m = portfolio.compute_metrics(eq, ndx)
+    reg = registry.Registry(path=str(tmp_path / "reg.sqlite"))
+    reg.insert("model", {}, m.__dict__)
+    top = reg.top("sharpe")
+    assert "model" in top["model_id"].values

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1,0 +1,9 @@
+import pandas as pd
+from whitelight.synthetic import make_leveraged_series
+
+
+def test_make_leveraged_series():
+    rets = pd.Series([0.01, -0.02, 0.03])
+    synth = make_leveraged_series(rets, leverage=3.0, fee_annual=0, borrow_cost_annual=0)
+    expected = (1 + 3 * rets).cumprod()
+    pd.testing.assert_series_equal(synth, expected, check_names=False)


### PR DESCRIPTION
## Summary
- implement data download with yfinance, calendar alignment and caching
- add synthetic leveraged series, indicators, position sizing and strategy modules
- provide CLI, Monte Carlo search and SQLite registry
- include unit tests for indicators, synthetic series, metrics and smoke backtest

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba956112a083319d5fe5bf6450c726