### PR TITLE
Fix CLI backtest when cached data uses ticker index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .cache/
 registry.sqlite
 synthetic.parquet
+*.egg-info/

--- a/src/whitelight/cli.py
+++ b/src/whitelight/cli.py
@@ -12,6 +12,24 @@ from . import data, synthetic, strategy, portfolio, registry, reports
 app = typer.Typer(help="Whitelight backtesting toolkit")
 
 
+def _extract_close(df: pd.DataFrame, name: str) -> pd.Series:
+    """Return the ``close`` column as a Series indexed by date.
+
+    Depending on caching or upstream changes, ``data.download_price_data`` may
+    yield DataFrames with a ``Ticker`` level in the index or with an extra
+    column dimension. This helper normalises the structure so callers receive a
+    plain ``Series`` indexed only by date and named according to ``name``.
+    """
+
+    series = df["close"]
+    if isinstance(series, pd.DataFrame):
+        # Drop any redundant column level
+        series = series.iloc[:, 0]
+    if isinstance(series.index, pd.MultiIndex) and "Ticker" in series.index.names:
+        series = series.droplevel("Ticker")
+    return series.rename(name)
+
+
 @app.command()
 def download(start: str = "1999-01-01", end: Optional[str] = None) -> None:
     """Download core datasets and cache them locally."""
@@ -42,9 +60,9 @@ def backtest(config: Optional[Path] = None) -> None:
     sqqq = data.download_price_data("SQQQ")
     df = pd.concat(
         [
-            ndx["close"].rename("ndx"),
-            tqqq["close"].rename("tqqq"),
-            sqqq["close"].rename("sqqq"),
+            _extract_close(ndx, "ndx"),
+            _extract_close(tqqq, "tqqq"),
+            _extract_close(sqqq, "sqqq"),
         ],
         axis=1,
         join="inner",
@@ -63,9 +81,9 @@ def montecarlo(n: int = 100) -> None:
     sqqq = data.download_price_data("SQQQ")
     df = pd.concat(
         [
-            ndx["close"].rename("ndx"),
-            tqqq["close"].rename("tqqq"),
-            sqqq["close"].rename("sqqq"),
+            _extract_close(ndx, "ndx"),
+            _extract_close(tqqq, "tqqq"),
+            _extract_close(sqqq, "sqqq"),
         ],
         axis=1,
         join="inner",
@@ -73,8 +91,14 @@ def montecarlo(n: int = 100) -> None:
     reg = registry.Registry()
     from . import montecarlo as mc
 
-    mc.run_montecarlo(df, n, reg)
+    best = mc.run_montecarlo(df, n, reg)
     typer.echo("Monte Carlo completed")
+    eq_best = strategy.backtest(df, best.params)
+    reports.plot_equity(eq_best, "best_equity.png")
+    typer.echo(
+        f"Best model {best.model_id} Sharpe {best.metrics.get('sharpe', 0):.2f}"
+        " saved to best_equity.png"
+    )
 
 
 @app.command()
@@ -93,3 +117,7 @@ def top(metric: str = "sharpe", k: int = 20) -> None:
     reg = registry.Registry()
     df = reg.top(metric, k)
     typer.echo(df.to_string(index=False))
+
+
+if __name__ == "__main__":
+    app()

--- a/src/whitelight/data.py
+++ b/src/whitelight/data.py
@@ -56,7 +56,11 @@ def download_price_data(
         df = raw[["Close"]].rename(columns={"Close": "close"})
         cal = mcal.get_calendar("XNYS")
         sched = cal.schedule(start_date=start, end_date=end)
-        all_days = mcal.date_range(sched, frequency="1D")
+        # ``mcal.date_range`` returns timezone-aware timestamps while
+        # ``yfinance`` provides a timezone-naive index. Reindexing with mismatched
+        # timezone information raises a ``TypeError``. Drop the timezone
+        # component so both indexes align on naive datetimes.
+        all_days = mcal.date_range(sched, frequency="1D").tz_localize(None)
         df = df.reindex(all_days, method="ffill")
         CACHE[key] = df
     if len(df) < 252 * 20:

--- a/src/whitelight/montecarlo.py
+++ b/src/whitelight/montecarlo.py
@@ -37,9 +37,17 @@ def _evaluate(df, seed: int) -> Result:
     return Result(str(seed), params, m.__dict__)
 
 
-def run_montecarlo(df, n: int, registry: Registry) -> None:
-    def worker(seed: int):
+def run_montecarlo(df, n: int, registry: Registry) -> Result:
+    """Evaluate ``n`` random models and persist results.
+
+    Returns the :class:`Result` with the highest Sharpe ratio so callers can
+    perform additional reporting (e.g. plot its equity curve).
+    """
+
+    def worker(seed: int) -> Result:
         res = _evaluate(df, seed)
         registry.insert(res.model_id, res.params, res.metrics)
+        return res
 
-    Parallel(n_jobs=-1)(delayed(worker)(s) for s in range(n))
+    results = Parallel(n_jobs=-1)(delayed(worker)(s) for s in range(n))
+    return max(results, key=lambda r: r.metrics.get("sharpe", float("-inf")))


### PR DESCRIPTION
## Summary
- normalize downloaded price data by stripping ticker index/column levels before concatenation
- reuse helper for both backtest and montecarlo commands
- return best Monte Carlo result and plot its equity curve

## Testing
- `pip install -e .`
- `pytest`
- `python -m whitelight.cli backtest` *(fails: ProxyError and empty data leads to IndexError)*

------
https://chatgpt.com/codex/tasks/task_e_68baaf42d1e88331888e5f89b1a4a6e5